### PR TITLE
Check memtable write error and sync file before remove temp log file

### DIFF
--- a/pkg/lsmt/flush.go
+++ b/pkg/lsmt/flush.go
@@ -26,7 +26,14 @@ func (f *flusher) flush() string {
 	}
 	defer file.Close()
 
-	f.memtable.Write(file)
+	_, err = f.memtable.Write(file)
+	if err != nil {
+		log.Panic(err)
+	}
+	err = file.Sync()
+	if err != nil {
+		log.Panic(err)
+	}
 
 	log.Printf("[DEBUG] Removing old append only log file at path=%s", f.memtable.logFilename)
 	err = os.Remove(f.memtable.logFilename)


### PR DESCRIPTION
Hi Alexander, I think there is a bug on `flusher.flush` method, it's necessary to check the write error and make sure written data is synced to disk, otherwise if computer crashed after calling `os.Remove` and the written data is not flushed or there is error during the write process, the data will be lost and mdb cannot recover them.

BTW, Thank you for public mdb to github. I'm learning how to build a lsm tree storage by myself, and your code helps me a lot!